### PR TITLE
adding a link for Brazilian Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [Resources](resources.md)
 
 ## Translations
-[español](intl/es/README.md)  [français](intl/fr/FAQ-fr.md) [русский](intl/ru/README-ru.md) [português brasileiro](intl/pt-br/LEIAME.md)
+[español](intl/es/README.md)  [français](intl/fr/FAQ-fr.md) [русский](intl/ru/README-ru.md) [português do Brasil](intl/pt-br/LEIAME.md)
 
 If you want to help by providing a translation of content/rules in the language you know, submit a pull request (or DM me on Twitter @ka11away), adding a sub-folder in the 'intl' folder with the files of the translation there.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [Resources](resources.md)
 
 ## Translations
-[español](intl/es/README.md)  [français](intl/fr/FAQ-fr.md) [русский](intl/ru/README-ru.md)
+[español](intl/es/README.md)  [français](intl/fr/FAQ-fr.md) [русский](intl/ru/README-ru.md) [português brasileiro](intl/pt-br/LEIAME.md)
 
 If you want to help by providing a translation of content/rules in the language you know, submit a pull request (or DM me on Twitter @ka11away), adding a sub-folder in the 'intl' folder with the files of the translation there.
 


### PR DESCRIPTION
is this a correct way to do this? I found two ways to say it (on Wikipedia): 1) português do Brasil  or 2)  português brasileiro @renatogpires 