### PR TITLE
Fix typo in md syntax

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -10,7 +10,7 @@ June 25th, 2016. [PUT YOUR DATE HERE]
 1. I will tweet about my progress every day -> using the hashtag #100DaysOfCode
 2. If I code at work, that time won't count towards the challenge.
 3. I will push code to GitHub every day so that anyone can see my progress.
-4. I will update the (Log)[log.md] with the day's progress and provide a link so that others can see my progress.
+4. I will update the [Log](log.md) with the day's progress and provide a link so that others can see my progress.
 5. I will work on real projects, facing real challenges. The time spent doing tutorials, online courses and other similar resources will NOT count towards this challenge. (If you've just started learning to code, read [FAQ](FAQ.md))
 
 


### PR DESCRIPTION
The link to Log.md in the file had the brackets the wrong way around causing it to not actually link to what it said it did.