### PR TITLE
Updated URL

### DIFF
--- a/intl/bn/resources.md
+++ b/intl/bn/resources.md
@@ -12,7 +12,7 @@
 # #100DaysOfCode এর বাড়তি কিছু রিসোর্সসমূহ
 
 ## সহায়ক প্রবন্ধ
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## প্রকল্প এবং ধারনাসমূহ
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/ch/resources.md
+++ b/intl/ch/resources.md
@@ -12,7 +12,7 @@
 # 其它关于 #100DaysOfCode 的资源
 
 ## 有帮助的文章
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Projects和想法
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/de/quellen.md
+++ b/intl/de/quellen.md
@@ -12,7 +12,7 @@
 # Zusätzliche Quellen für die #100DaysOfCode
 
 ## Hilfreiche Artikel
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Projekte und Ideen
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/es/diario.md
+++ b/intl/es/diario.md
@@ -16,7 +16,7 @@
 
 ## Artículos útiles (en inglés)
 
-1.  [Gentle Explanation of 'this' keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1.  [Gentle Explanation of 'this' keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Proyectos e ideas
 

--- a/intl/fr/resources-fr.md
+++ b/intl/fr/resources-fr.md
@@ -15,7 +15,7 @@
 # Ressources supplémentaires sur les #100DaysOfCode
 
 ## Articles utiles
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Idées et projets
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/ja/resources.md
+++ b/intl/ja/resources.md
@@ -12,7 +12,7 @@
 # #100DaysOfCodeのその他のリソース
 
 ## 参考になる記事
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## プロジェクトやアイデア
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/ko/resources.md
+++ b/intl/ko/resources.md
@@ -12,7 +12,7 @@
 # #100DaysOfCode (#100일코딩) 추가 참고 자료
 
 ## 도움이 되는 게시물(영문)
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## 프로젝트 및 아이디어(영문)
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/no/resources.md
+++ b/intl/no/resources.md
@@ -14,7 +14,7 @@
 
 ### Nyttige artikler
 
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ### Projekter og ideér
 

--- a/intl/pl/materiały.md
+++ b/intl/pl/materiały.md
@@ -12,7 +12,7 @@
 # Materiały Dodatkowe #100DaysOfCode
 
 ## Artykuły Pomocnicze
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Projekty i Pomysły
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/intl/pt-br/recursos.md
+++ b/intl/pt-br/recursos.md
@@ -14,7 +14,7 @@
 
 ## Artigos úteis
 
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Projetos e ideias
 

--- a/intl/ua/resources.md
+++ b/intl/ua/resources.md
@@ -12,7 +12,7 @@
 # Додаткові ресурси #100DaysOfCode
 
 ## Корисні статті
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Проекти та ідеї
 1. [FreeCodeCamp](https://www.freecodecamp.com)

--- a/resources.md
+++ b/resources.md
@@ -12,7 +12,7 @@
 # Additional Resources on the #100DaysOfCode
 
 ## Helpful Articles
-1. [Gentle Explanation of 'this keyword in JavaScript](http://rainsoft.io/gentle-explanation-of-this-in-javascript/)
+1. [Gentle Explanation of 'this keyword in JavaScript](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/)
 
 ## Projects and Ideas
 1. [FreeCodeCamp](https://www.freecodecamp.com)


### PR DESCRIPTION
rainsoft.io was protected by an expired SSL certificate. Appears this will not be resolved (expired for 6 months). The URL redirects to the 1 that has replaced it.

Fixes #225 