### PR TITLE
fix: URL change for original blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want to help by providing a translation of content/rules in the language 
 
 0.  Check out [the Official Site](http://100daysofcode.com/) for the #100DaysOfCode movement. Connect with others on the platform of your choice from this list: www.100DaysOfCode.com/connect
     Also, [here](https://join.slack.com/t/100xcode/shared_invite/zt-eivg7x1x-wgNPDh7ug_u4GcUwZNT8Zg) is a invite link to the 100DaysOfCode Slack channel
-1.  Read [Join the #100DaysOfCode](https://medium.freecodecamp.com/join-the-100daysofcode-556ddb4579e4)
+1.  Read [Join the #100DaysOfCode](https://www.freecodecamp.org/news/join-the-100daysofcode-556ddb4579e4/)
 2.  Fork this repo and commit to the [Log](log.md) or to the Alternative, rapid [R1 Log](r1-log.md) (R1 stands for Round 1) daily. [Example](https://github.com/Kallaway/100-days-kallaway-log).
 3.  **Code minimum an hour every day for the next 100 days.**
 4.  **Encourage at least two other people in the challenge on Twitter every day! Pay it forward!**


### PR DESCRIPTION
This pull request updates the URL for the FreeCodeCamp blog post. The blog has moved from Medium subdomain to `https://www.freecodecamp.org/news/`.