### PR TITLE
Bolded colon in Today's Progress

### DIFF
--- a/log.md
+++ b/log.md
@@ -12,7 +12,7 @@
 ### Day 0: February 30, 2016 (Example 2)
 ##### (delete me or comment me out)
 
-**Today's Progress**: Fixed CSS, worked on canvas functionality for the app.
+**Today's Progress:** Fixed CSS, worked on canvas functionality for the app.
 
 **Thoughts**: I really struggled with CSS, but, overall, I feel like I am slowly getting better at it. Canvas is still new for me, but I managed to figure out some basic functionality.
 


### PR DESCRIPTION
Hi, I was logging my progress for the day and noticed the colon wasn't bolded in `Today's Progress` unlike the rest of the sections. So I'm just opening a PR for it :smile: 